### PR TITLE
BUG: Fix homepage and screenshoturls extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ project(AblationPlanner)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "https://www.slicer.org/wiki/Documentation/Nightly/Extensions/AblationPlanner")
+set(EXTENSION_HOMEPAGE "https://github.com/naterex23/SlicerAblationPlanner")
 set(EXTENSION_CATEGORY "Quantification")
 set(EXTENSION_CONTRIBUTORS "Nathaniel Rex (Brown University), Scott Collins (Rhode Island Hospital)")
-set(EXTENSION_DESCRIPTION "This extension enables the user to place virtual ablation profiles and evaluate a theoretical margin associated with these profiles.  ")
+set(EXTENSION_DESCRIPTION "This extension enables the user to place virtual ablation profiles and evaluate a theoretical margins associated with these profiles.")
 set(EXTENSION_ICONURL "https://github.com/naterex23/SlicerAblationPlanner/raw/main/AblationPlanner/Resources/Icons/AblationPlanner.png")
-set(EXTENSION_SCREENSHOTURLS "https://github.com/naterex23/SlicerAblationPlanner/raw/main/Screenshots/minimum_required_inputs.png, https://github.com/naterex23/SlicerAblationPlanner/raw/main/Screenshots/minimum_required_placement.png, https://github.com/naterex23/SlicerAblationPlanner/raw/main/Screenshots/ablation_steps.png, https://github.com/naterex23/SlicerAblationPlanner/raw/main/Screenshots/ablation_outputs.png, https://github.com/naterex23/SlicerAblationPlanner/raw/main/Screenshots/margin_colors.png")
+set(EXTENSION_SCREENSHOTURLS "https://github.com/naterex23/SlicerAblationPlanner/raw/main/Screenshots/combined_probes.png https://github.com/naterex23/SlicerAblationPlanner/raw/main/Screenshots/fiducial_placement.png https://github.com/naterex23/SlicerAblationPlanner/raw/main/Screenshots/margin_colors.png")
 set(EXTENSION_DEPENDS "ModelToModelDistance") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Update values based on content of `AblationPlanner.s4ext` associated with Slicer/ExtensionsIndex@407be81e9

These changes are done anticipating the integration of the following pull requests:
* https://github.com/Slicer/Slicer/pull/7629
* https://github.com/Slicer/ExtensionsIndex/pull/2011